### PR TITLE
Add invalid field value to Java LIVR validator

### DIFF
--- a/src/main/java/livr/Validator.java
+++ b/src/main/java/livr/Validator.java
@@ -194,6 +194,7 @@ public class Validator {
                     } else {
                         errors.put(k, errCode);
                     }
+                    break;
                 } else if (!v.getFieldResultArr().isEmpty()) {
                     result.put(k, v.getFieldResultArr().get(0));
                 } else if (finalData.get(k) != null && !result.containsKey(k)) {

--- a/src/main/java/livr/Validator.java
+++ b/src/main/java/livr/Validator.java
@@ -1,14 +1,18 @@
 package livr;
 
 import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Function;
 
 /**
  * Created by vladislavbaluk on 9/29/2017.
@@ -182,8 +186,14 @@ public class Validator {
                 v.setArgs(toMap(finalData));
                 Object errCode = v.getFunction().apply(v);
                 if (errCode != null && !errCode.toString().isEmpty()) {
-                    errors.put(k, errCode);
-                    break;
+                    if (errCode instanceof String) {
+                        final JSONObject error = new JSONObject();
+                        error.put("code", errCode);
+                        error.put("fieldValue", value);
+                        errors.put(k, error);
+                    } else {
+                        errors.put(k, errCode);
+                    }
                 } else if (!v.getFieldResultArr().isEmpty()) {
                     result.put(k, v.getFieldResultArr().get(0));
                 } else if (finalData.get(k) != null && !result.containsKey(k)) {

--- a/src/test/groovy/livr/AutoTrimTest.groovy
+++ b/src/test/groovy/livr/AutoTrimTest.groovy
@@ -28,13 +28,21 @@ class AutoTrimTest extends Specification {
 
         assert output == null;
         JSONAssert.assertEquals(validator.getErrors().toJSONString(), "{" +
-                "                \"code\": \"REQUIRED\"," +
-                "                \"password\": \"TOO_SHORT\"," +
-                "                \"address\":" +
-                "                {" +
-                "                \"street\": \"TOO_SHORT\"" +
-                "                }" +
-                "                }", false);
+                "  \"password\": {" +
+                "    \"code\": \"TOO_SHORT\"," +
+                "    \"fieldValue\": \"12\"" +
+                "  }," +
+                "  \"code\": {" +
+                "    \"code\": \"REQUIRED\"," +
+                "    \"fieldValue\": \"\"" +
+                "  }," +
+                "  \"address\": {" +
+                "    \"street\": {" +
+                "      \"code\": \"TOO_SHORT\"," +
+                "      \"fieldValue\": \"hell\"" +
+                "    }" +
+                "  }" +
+                "}", false);
 
     }
 

--- a/src/test/resources/aliases_negative/01-adult_age/errors.json
+++ b/src/test/resources/aliases_negative/01-adult_age/errors.json
@@ -4,7 +4,7 @@
     "fieldValue": 16
   },
   "age4": {
-    "code": "TOO_LOW",
+    "code": "NOT_POSITIVE_INTEGER",
     "fieldValue": -20
   },
   "age3": {

--- a/src/test/resources/aliases_negative/01-adult_age/errors.json
+++ b/src/test/resources/aliases_negative/01-adult_age/errors.json
@@ -1,6 +1,18 @@
 {
-    "age3": "TOO_LOW",
-    "age4": "NOT_POSITIVE_INTEGER",
-    "age3_custom_error": "WRONG_AGE",
-    "age4_custom_error": "WRONG_AGE"
+  "age3_custom_error": {
+    "code": "WRONG_AGE",
+    "fieldValue": 16
+  },
+  "age4": {
+    "code": "TOO_LOW",
+    "fieldValue": -20
+  },
+  "age3": {
+    "code": "TOO_LOW",
+    "fieldValue": 15
+  },
+  "age4_custom_error": {
+    "code": "WRONG_AGE",
+    "fieldValue": -10
+  }
 }

--- a/src/test/resources/aliases_negative/02-address/errors.json
+++ b/src/test/resources/aliases_negative/02-address/errors.json
@@ -1,8 +1,24 @@
 {
-    "address": {
-        "street": "REQUIRED",
-        "zip": "NOT_POSITIVE_INTEGER",
-        "city": "NOT_ALLOWED_VALUE"
+  "address": {
+    "zip": {
+      "code": "NOT_POSITIVE_INTEGER",
+      "fieldValue": -1232131
     },
-    "address_custom_error": "WRONG_ADDRESS"
+    "city": {
+      "code": "NOT_ALLOWED_VALUE",
+      "fieldValue": "Moscow"
+    },
+    "street": {
+      "code": "REQUIRED",
+      "fieldValue": ""
+    }
+  },
+  "address_custom_error": {
+    "code": "WRONG_ADDRESS",
+    "fieldValue": {
+      "zip": "12312",
+      "city": "Moscow",
+      "street": "My street"
+    }
+  }
 }

--- a/src/test/resources/aliases_negative/03-adult_age_in_user/errors.json
+++ b/src/test/resources/aliases_negative/03-adult_age_in_user/errors.json
@@ -1,8 +1,24 @@
 {
-    "user": {
-        "name": "REQUIRED",
-        "age1": "TOO_LOW",
-        "age2": "WRONG_AGE"
+  "user": {
+    "name": {
+      "code": "REQUIRED",
+      "fieldValue": ""
     },
-    "user_custom_error": "WRONG_USER"
+    "age2": {
+      "code": "WRONG_AGE",
+      "fieldValue": 15
+    },
+    "age1": {
+      "code": "TOO_LOW",
+      "fieldValue": 15
+    }
+  },
+  "user_custom_error": {
+    "code": "WRONG_USER",
+    "fieldValue": {
+      "name": "koorchik",
+      "age2": 22,
+      "age1": 15
+    }
+  }
 }

--- a/src/test/resources/negative/01-required/errors.json
+++ b/src/test/resources/negative/01-required/errors.json
@@ -1,5 +1,14 @@
 {
-    "first_name": "REQUIRED",
-    "last_name": "REQUIRED",
-    "middle_name": "REQUIRED"
+    "first_name": {
+        "code" : "REQUIRED",
+        "fieldValue" : ""
+    },
+    "last_name": {
+        "code" : "REQUIRED",
+        "fieldValue" : null
+    },
+    "middle_name": {
+        "code" : "REQUIRED",
+        "fieldValue" : null
+    }
 }

--- a/src/test/resources/negative/01-required/errors.json
+++ b/src/test/resources/negative/01-required/errors.json
@@ -1,14 +1,14 @@
 {
-    "first_name": {
-        "code" : "REQUIRED",
-        "fieldValue" : ""
-    },
-    "last_name": {
-        "code" : "REQUIRED",
-        "fieldValue" : null
-    },
-    "middle_name": {
-        "code" : "REQUIRED",
-        "fieldValue" : null
-    }
+  "last_name": {
+    "code": "REQUIRED",
+    "fieldValue": null
+  },
+  "middle_name": {
+    "code": "REQUIRED",
+    "fieldValue": null
+  },
+  "first_name": {
+    "code": "REQUIRED",
+    "fieldValue": ""
+  }
 }

--- a/src/test/resources/negative/02-not_empty/errors.json
+++ b/src/test/resources/negative/02-not_empty/errors.json
@@ -1,3 +1,6 @@
 {
-    "first_name": "CANNOT_BE_EMPTY"
+    "first_name": {
+        "code" : "CANNOT_BE_EMPTY",
+        "fieldValue" : ""
+    }
 }

--- a/src/test/resources/negative/02-not_empty/errors.json
+++ b/src/test/resources/negative/02-not_empty/errors.json
@@ -1,6 +1,6 @@
 {
-    "first_name": {
-        "code" : "CANNOT_BE_EMPTY",
-        "fieldValue" : ""
-    }
+  "first_name": {
+    "code": "CANNOT_BE_EMPTY",
+    "fieldValue": ""
+  }
 }

--- a/src/test/resources/negative/03-one_of/errors.json
+++ b/src/test/resources/negative/03-one_of/errors.json
@@ -1,11 +1,39 @@
 {
-    "city1": "NOT_ALLOWED_VALUE",
-    "city2": "NOT_ALLOWED_VALUE",
-    "city3": "NOT_ALLOWED_VALUE",
-    "number1": "NOT_ALLOWED_VALUE",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+    "city1": {
+        "code": "NOT_ALLOWED_VALUE",
+        "fieldValue": "New York"
+    },
+    "value_is_hash": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": {
+            "test": 1
+        }
+    },
+    "value_is_empty_hash": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": {}
+    },
+    "value_is_empty_array": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": []
+    },
+    "city2": {
+        "code": "NOT_ALLOWED_VALUE",
+        "fieldValue": "New York"
+    },
+    "value_is_array": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": [
+            "test",
+            1
+        ]
+    },
+    "number1": {
+        "code": "NOT_ALLOWED_VALUE",
+        "fieldValue": "1.0"
+    },
+    "city3": {
+        "code": "NOT_ALLOWED_VALUE",
+        "fieldValue": "New York"
+    }
 }

--- a/src/test/resources/negative/04-min_length/errors.json
+++ b/src/test/resources/negative/04-min_length/errors.json
@@ -1,10 +1,35 @@
 {
-    "first_name": "TOO_SHORT",
-    "last_name": "TOO_SHORT",
-    "middle_name": "TOO_SHORT",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "last_name": {
+    "code": "TOO_SHORT",
+    "fieldValue": "Pupkin"
+  },
+  "middle_name": {
+    "code": "TOO_SHORT",
+    "fieldValue": "Some name"
+  },
+  "first_name": {
+    "code": "TOO_SHORT",
+    "fieldValue": "Vasya"
+  }
 }

--- a/src/test/resources/negative/05-max_length/errors.json
+++ b/src/test/resources/negative/05-max_length/errors.json
@@ -1,10 +1,35 @@
 {
-    "first_name": "TOO_LONG",
-    "last_name": "TOO_LONG",
-    "middle_name": "TOO_LONG",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "last_name": {
+    "code": "TOO_LONG",
+    "fieldValue": "Pupkin"
+  },
+  "middle_name": {
+    "code": "TOO_LONG",
+    "fieldValue": "Some name"
+  },
+  "first_name": {
+    "code": "TOO_LONG",
+    "fieldValue": "Vasya"
+  }
 }

--- a/src/test/resources/negative/06-length_equal/errors.json
+++ b/src/test/resources/negative/06-length_equal/errors.json
@@ -1,10 +1,35 @@
 {
-    "first_name": "TOO_LONG",
-    "last_name": "TOO_SHORT",
-    "middle_name": "TOO_LONG",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "last_name": {
+    "code": "TOO_SHORT",
+    "fieldValue": "Pupkin"
+  },
+  "middle_name": {
+    "code": "TOO_LONG",
+    "fieldValue": "Some name"
+  },
+  "first_name": {
+    "code": "TOO_LONG",
+    "fieldValue": "Vasya"
+  }
 }

--- a/src/test/resources/negative/07-length_between/errors.json
+++ b/src/test/resources/negative/07-length_between/errors.json
@@ -1,10 +1,35 @@
 {
-    "first_name": "TOO_SHORT",
-    "last_name": "TOO_LONG",
-    "middle_name": "TOO_LONG",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "last_name": {
+    "code": "TOO_LONG",
+    "fieldValue": "Pupkin"
+  },
+  "middle_name": {
+    "code": "TOO_LONG",
+    "fieldValue": "Some name"
+  },
+  "first_name": {
+    "code": "TOO_SHORT",
+    "fieldValue": "Vasya"
+  }
 }

--- a/src/test/resources/negative/08-like/errors.json
+++ b/src/test/resources/negative/08-like/errors.json
@@ -1,11 +1,39 @@
 {
-    "first_name": "WRONG_FORMAT",
-    "last_name": "WRONG_FORMAT",
-    "middle_name": "WRONG_FORMAT",
-    "age": "WRONG_FORMAT",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+    "value_is_hash": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": {
+            "test": 1
+        }
+    },
+    "value_is_empty_hash": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": {}
+    },
+    "value_is_empty_array": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": []
+    },
+    "value_is_array": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": [
+            "test",
+            1
+        ]
+    },
+    "last_name": {
+        "code": "WRONG_FORMAT",
+        "fieldValue": "Pupkin"
+    },
+    "middle_name": {
+        "code": "WRONG_FORMAT",
+        "fieldValue": "Ivanovich"
+    },
+    "first_name": {
+        "code": "WRONG_FORMAT",
+        "fieldValue": "Vasya"
+    },
+    "age": {
+        "code": "WRONG_FORMAT",
+        "fieldValue": "35"
+    }
 }

--- a/src/test/resources/negative/09-integer/errors.json
+++ b/src/test/resources/negative/09-integer/errors.json
@@ -1,11 +1,39 @@
 {
-    "number1": "NOT_INTEGER",
-    "number2": "NOT_INTEGER",
-    "number3": "NOT_INTEGER",
-
-    "value_is_string":      "NOT_INTEGER",
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_string": {
+    "code": "NOT_INTEGER",
+    "fieldValue": "some_string"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number3": {
+    "code": "NOT_INTEGER",
+    "fieldValue": -1.12
+  },
+  "number1": {
+    "code": "NOT_INTEGER",
+    "fieldValue": "A"
+  },
+  "number2": {
+    "code": "NOT_INTEGER",
+    "fieldValue": "0.12"
+  }
 }

--- a/src/test/resources/negative/10-positive_integer/errors.json
+++ b/src/test/resources/negative/10-positive_integer/errors.json
@@ -1,11 +1,39 @@
 {
-    "number1": "NOT_POSITIVE_INTEGER",
-    "number2": "NOT_POSITIVE_INTEGER",
-    "number3": "NOT_POSITIVE_INTEGER",
-
-    "value_is_string":      "NOT_POSITIVE_INTEGER",
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_string": {
+    "code": "NOT_POSITIVE_INTEGER",
+    "fieldValue": "some_string"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number3": {
+    "code": "NOT_POSITIVE_INTEGER",
+    "fieldValue": "0"
+  },
+  "number1": {
+    "code": "NOT_POSITIVE_INTEGER",
+    "fieldValue": "A"
+  },
+  "number2": {
+    "code": "NOT_POSITIVE_INTEGER",
+    "fieldValue": "-10"
+  }
 }

--- a/src/test/resources/negative/11-decimal/errors.json
+++ b/src/test/resources/negative/11-decimal/errors.json
@@ -1,11 +1,39 @@
 {
-    "number1": "NOT_DECIMAL",
-    "number2": "NOT_DECIMAL",
-    "number3": "NOT_DECIMAL",
-
-    "value_is_string":      "NOT_DECIMAL",
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_string": {
+    "code": "NOT_DECIMAL",
+    "fieldValue": "some_string"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number3": {
+    "code": "NOT_DECIMAL",
+    "fieldValue": "1,12"
+  },
+  "number1": {
+    "code": "NOT_DECIMAL",
+    "fieldValue": "A"
+  },
+  "number2": {
+    "code": "NOT_DECIMAL",
+    "fieldValue": "12.12.12"
+  }
 }

--- a/src/test/resources/negative/12-positive_decimal/errors.json
+++ b/src/test/resources/negative/12-positive_decimal/errors.json
@@ -1,11 +1,35 @@
 {
-    "number1": "NOT_POSITIVE_DECIMAL",
-    "number2": "NOT_POSITIVE_DECIMAL",
-    "number3": "NOT_POSITIVE_DECIMAL",
-
-    "value_is_string":      "NOT_POSITIVE_DECIMAL",
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_string": {
+    "code": "NOT_POSITIVE_DECIMAL",
+    "fieldValue": "some_string"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number3": {
+    "code": "NOT_POSITIVE_DECIMAL",
+    "fieldValue": -1.12
+  },
+  "number1": {
+    "code": "NOT_POSITIVE_DECIMAL",
+    "fieldValue": "10.10.10"
+  }
 }

--- a/src/test/resources/negative/13-max_number/errors.json
+++ b/src/test/resources/negative/13-max_number/errors.json
@@ -1,10 +1,35 @@
 {
-    "number1": "TOO_HIGH",
-    "number2": "TOO_HIGH",
-
-    "value_is_string":      "NOT_NUMBER",
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_string": {
+    "code": "NOT_NUMBER",
+    "fieldValue": "some_string"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number1": {
+    "code": "TOO_HIGH",
+    "fieldValue": "15"
+  },
+  "number2": {
+    "code": "TOO_HIGH",
+    "fieldValue": "25.5"
+  }
 }

--- a/src/test/resources/negative/14-min_number/errors.json
+++ b/src/test/resources/negative/14-min_number/errors.json
@@ -1,10 +1,35 @@
 {
-    "number1": "TOO_LOW",
-    "number2": "TOO_LOW",
-
-    "value_is_string":      "NOT_NUMBER",
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_string": {
+    "code": "NOT_NUMBER",
+    "fieldValue": "some_string"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number1": {
+    "code": "TOO_LOW",
+    "fieldValue": "5"
+  },
+  "number2": {
+    "code": "TOO_LOW",
+    "fieldValue": "-10"
+  }
 }

--- a/src/test/resources/negative/15-number_beetween/errors.json
+++ b/src/test/resources/negative/15-number_beetween/errors.json
@@ -1,10 +1,35 @@
 {
-    "number1": "TOO_LOW",
-    "number2": "TOO_HIGH",
-
-    "value_is_string":      "NOT_NUMBER",
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_string": {
+    "code": "NOT_NUMBER",
+    "fieldValue": "some_string"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number1": {
+    "code": "TOO_LOW",
+    "fieldValue": "5"
+  },
+  "number2": {
+    "code": "TOO_HIGH",
+    "fieldValue": "40"
+  }
 }

--- a/src/test/resources/negative/16-email/errors.json
+++ b/src/test/resources/negative/16-email/errors.json
@@ -1,12 +1,43 @@
 {
-    "email1": "WRONG_EMAIL",
-    "email2": "WRONG_EMAIL",
-    "email3": "WRONG_EMAIL",
-    "email4": "WRONG_EMAIL",
-    "email5": "WRONG_EMAIL",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "email3": {
+    "code": "WRONG_EMAIL",
+    "fieldValue": "test+test.t_e_s_t@ma_il.in.ua"
+  },
+  "email2": {
+    "code": "WRONG_EMAIL",
+    "fieldValue": "test@test@mail.com.ua"
+  },
+  "email1": {
+    "code": "WRONG_EMAIL",
+    "fieldValue": "testmail.com"
+  },
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "email5": {
+    "code": "WRONG_EMAIL",
+    "fieldValue": "username@mail.c om"
+  },
+  "email4": {
+    "code": "WRONG_EMAIL",
+    "fieldValue": "user name@gmail.com"
+  }
 }

--- a/src/test/resources/negative/17-equal_to_field/errors.json
+++ b/src/test/resources/negative/17-equal_to_field/errors.json
@@ -1,10 +1,35 @@
 {
-    "field1": "FIELDS_NOT_EQUAL",
-    "field2": "FIELDS_NOT_EQUAL",
-    "field3": "FIELDS_NOT_EQUAL",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "field1": {
+    "code": "FIELDS_NOT_EQUAL",
+    "fieldValue": "some value1"
+  },
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "field3": {
+    "code": "FIELDS_NOT_EQUAL",
+    "fieldValue": "some value"
+  },
+  "field2": {
+    "code": "FIELDS_NOT_EQUAL",
+    "fieldValue": "some value"
+  }
 }

--- a/src/test/resources/negative/18-nested_object/errors.json
+++ b/src/test/resources/negative/18-nested_object/errors.json
@@ -1,9 +1,24 @@
 {
-    "address": {
-        "country": "NOT_ALLOWED_VALUE",
-        "zip": "NOT_POSITIVE_INTEGER",
-        "street": "REQUIRED",
-        "building": "NOT_POSITIVE_INTEGER"
+  "address": {
+    "zip": {
+      "code": "NOT_POSITIVE_INTEGER",
+      "fieldValue": "AAA"
     },
-    "address2": "FORMAT_ERROR"
+    "country": {
+      "code": "NOT_ALLOWED_VALUE",
+      "fieldValue": "Russia"
+    },
+    "street": {
+      "code": "REQUIRED",
+      "fieldValue": ""
+    },
+    "building": {
+      "code": "NOT_POSITIVE_INTEGER",
+      "fieldValue": "-10"
+    }
+  },
+  "address2": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": "Should be hash"
+  }
 }

--- a/src/test/resources/negative/19-list_of/errors.json
+++ b/src/test/resources/negative/19-list_of/errors.json
@@ -1,6 +1,45 @@
 {
-    "product_ids1": [ "NOT_POSITIVE_INTEGER", "REQUIRED", null, "TOO_HIGH" ],
-    "product_ids2": [ "NOT_POSITIVE_INTEGER", "REQUIRED", null, "TOO_HIGH" ],
-    "product_ids3": [ "NOT_POSITIVE_INTEGER", null, null, null ],
-    "user_ids": "FORMAT_ERROR"
+  "user_ids": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": "not an array"
+  },
+  "product_ids3": [
+    {
+      "code": "NOT_POSITIVE_INTEGER",
+      "fieldValue": -10
+    },
+    null,
+    null,
+    null
+  ],
+  "product_ids2": [
+    {
+      "code": "NOT_POSITIVE_INTEGER",
+      "fieldValue": -10
+    },
+    {
+      "code": "REQUIRED",
+      "fieldValue": ""
+    },
+    null,
+    {
+      "code": "TOO_HIGH",
+      "fieldValue": 120
+    }
+  ],
+  "product_ids1": [
+    {
+      "code": "NOT_POSITIVE_INTEGER",
+      "fieldValue": -10
+    },
+    {
+      "code": "REQUIRED",
+      "fieldValue": ""
+    },
+    null,
+    {
+      "code": "TOO_HIGH",
+      "fieldValue": 120
+    }
+  ]
 }

--- a/src/test/resources/negative/20-list_of_objects/errors.json
+++ b/src/test/resources/negative/20-list_of_objects/errors.json
@@ -1,14 +1,26 @@
 {
-    "products": [
-        {
-            "product_id": "NOT_POSITIVE_INTEGER",
-            "quantity": "REQUIRED"
-        },
-        null,
-        {
-            "product_id": "NOT_POSITIVE_INTEGER"
-        },
-       "FORMAT_ERROR"
-    ],
-    "users": "FORMAT_ERROR"
+  "users": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": "not an array"
+  },
+  "products": [
+    {
+      "quantity": {
+        "code": "REQUIRED",
+        "fieldValue": ""
+      },
+      "product_id": {
+        "code": "NOT_POSITIVE_INTEGER",
+        "fieldValue": 0
+      }
+    },
+    null,
+    {
+      "product_id": {
+        "code": "NOT_POSITIVE_INTEGER",
+        "fieldValue": -10
+      }
+    },
+    "FORMAT_ERROR"
+  ]
 }

--- a/src/test/resources/negative/21-list_of_different_objects/errors.json
+++ b/src/test/resources/negative/21-list_of_different_objects/errors.json
@@ -1,17 +1,32 @@
 {
-    "order_id": "NOT_POSITIVE_INTEGER",
-    "products": [
-        {
-            "material_id": "NOT_POSITIVE_INTEGER",
-            "quantity": "REQUIRED"
-        },
-        {
-            "warehouse_id": "NOT_POSITIVE_INTEGER"
-        },
-        {
-            "name": "TOO_LONG"
-        },
-        "FORMAT_ERROR",
-        "FORMAT_ERROR"
-    ]
+  "order_id": {
+    "code": "NOT_POSITIVE_INTEGER",
+    "fieldValue": "-10"
+  },
+  "products": [
+    {
+      "quantity": {
+        "code": "REQUIRED",
+        "fieldValue": ""
+      },
+      "material_id": {
+        "code": "NOT_POSITIVE_INTEGER",
+        "fieldValue": 0
+      }
+    },
+    {
+      "warehouse_id": {
+        "code": "NOT_POSITIVE_INTEGER",
+        "fieldValue": -100
+      }
+    },
+    {
+      "name": {
+        "code": "TOO_LONG",
+        "fieldValue": "Very Long Name"
+      }
+    },
+    "FORMAT_ERROR",
+    "FORMAT_ERROR"
+  ]
 }

--- a/src/test/resources/negative/22-not_empty_list/errors.json
+++ b/src/test/resources/negative/22-not_empty_list/errors.json
@@ -1,7 +1,22 @@
 {
-    "list1": "CANNOT_BE_EMPTY",
-    "list2": "CANNOT_BE_EMPTY",
-    "not_list": "FORMAT_ERROR",
-    "empty_field": "CANNOT_BE_EMPTY",
-    "missed_field":  "CANNOT_BE_EMPTY"
+  "list1": {
+    "code": "CANNOT_BE_EMPTY",
+    "fieldValue": []
+  },
+  "list2": {
+    "code": "CANNOT_BE_EMPTY",
+    "fieldValue": []
+  },
+  "missed_field": {
+    "code": "CANNOT_BE_EMPTY",
+    "fieldValue": null
+  },
+  "empty_field": {
+    "code": "CANNOT_BE_EMPTY",
+    "fieldValue": ""
+  },
+  "not_list": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  }
 }

--- a/src/test/resources/negative/23-url/errors.json
+++ b/src/test/resources/negative/23-url/errors.json
@@ -1,10 +1,27 @@
 {
-    "url1": "WRONG_URL",
-    "url2": "WRONG_URL",
-    "url3": "WRONG_URL",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "url1": {
+    "code": "WRONG_URL",
+    "fieldValue": "www.google.com"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  }
 }

--- a/src/test/resources/negative/24-iso_date/errors.json
+++ b/src/test/resources/negative/24-iso_date/errors.json
@@ -1,10 +1,31 @@
 {
-    "iso_date1": "WRONG_DATE",
-    "iso_date2": "WRONG_DATE",
-    "iso_date3": "WRONG_DATE",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "iso_date3": {
+    "code": "WRONG_DATE",
+    "fieldValue": "2014-10-10T22:22"
+  },
+  "iso_date1": {
+    "code": "WRONG_DATE",
+    "fieldValue": "2014-13-10"
+  }
 }

--- a/src/test/resources/negative/25-eq/errors.json
+++ b/src/test/resources/negative/25-eq/errors.json
@@ -1,11 +1,39 @@
 {
-    "city1": "NOT_ALLOWED_VALUE",
-    "city2": "NOT_ALLOWED_VALUE",
-    "city3": "NOT_ALLOWED_VALUE",
-    "number1": "NOT_ALLOWED_VALUE",
-
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "city1": {
+    "code": "NOT_ALLOWED_VALUE",
+    "fieldValue": "New York"
+  },
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "city2": {
+    "code": "NOT_ALLOWED_VALUE",
+    "fieldValue": "New York"
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  },
+  "number1": {
+    "code": "NOT_ALLOWED_VALUE",
+    "fieldValue": "1.0"
+  },
+  "city3": {
+    "code": "NOT_ALLOWED_VALUE",
+    "fieldValue": "New York"
+  }
 }

--- a/src/test/resources/negative/26-string/errors.json
+++ b/src/test/resources/negative/26-string/errors.json
@@ -1,6 +1,23 @@
 {
-    "value_is_hash":        "FORMAT_ERROR",
-    "value_is_empty_hash":  "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {
+      "test": 1
+    }
+  },
+  "value_is_empty_hash": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": {}
+  },
+  "value_is_empty_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": []
+  },
+  "value_is_array": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": [
+      "test",
+      1
+    ]
+  }
 }

--- a/src/test/resources/negative/27-any_object/errors.json
+++ b/src/test/resources/negative/27-any_object/errors.json
@@ -1,6 +1,6 @@
 {
-    "value_is_string":      "FORMAT_ERROR",
-    "value_is_number":      "FORMAT_ERROR",
-    "value_is_array":       "FORMAT_ERROR",
-    "value_is_empty_array": "FORMAT_ERROR"
+  "value_is_string": {
+    "code": "FORMAT_ERROR",
+    "fieldValue": "test"
+  }
 }

--- a/src/test/resources/negative/28-variable_object/errors.json
+++ b/src/test/resources/negative/28-variable_object/errors.json
@@ -1,15 +1,39 @@
 {
-    "order_id": "NOT_POSITIVE_INTEGER",
-    "product1": {
-        "material_id": "NOT_POSITIVE_INTEGER",
-        "quantity": "REQUIRED"
-    },
     "product2": {
-        "warehouse_id": "NOT_POSITIVE_INTEGER"
+        "warehouse_id": {
+            "code": "NOT_POSITIVE_INTEGER",
+            "fieldValue": -100
+        }
+    },
+    "product1": {
+        "quantity": {
+            "code": "REQUIRED",
+            "fieldValue": ""
+        },
+        "material_id": {
+            "code": "NOT_POSITIVE_INTEGER",
+            "fieldValue": 0
+        }
+    },
+    "order_id": {
+        "code": "NOT_POSITIVE_INTEGER",
+        "fieldValue": "-10"
+    },
+    "product5": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": "Some Wrong Data"
+    },
+    "product4": {
+        "code": "FORMAT_ERROR",
+        "fieldValue": {
+            "product_type": "wrongtype",
+            "name": "Wrongtype"
+        }
     },
     "product3": {
-        "name": "TOO_LONG"
-    },
-    "product4": "FORMAT_ERROR",
-    "product5": "FORMAT_ERROR"
+        "name": {
+            "code": "TOO_LONG",
+            "fieldValue": "Very Long Name"
+        }
+    }
 }

--- a/src/test/resources/negative/29-or/errors.json
+++ b/src/test/resources/negative/29-or/errors.json
@@ -1,14 +1,32 @@
 {
-     "id1-1": "NOT_POSITIVE_INTEGER",
-     "id2-1": "NOT_POSITIVE_INTEGER",
-     "id3-1": "WRONG_EMAIL",
-     "products": [
-       {
-         "name": "REQUIRED",
-         "product_type": "NOT_ALLOWED_VALUE"
-       },
-       {
-         "name": "REQUIRED"
-       }
-    ]
+  "id3-1": {
+    "code": "WRONG_EMAIL",
+    "fieldValue": "Usermail.com"
+  },
+  "id2-1": {
+    "code": "NOT_POSITIVE_INTEGER",
+    "fieldValue": "Usermail.com"
+  },
+  "id1-1": {
+    "code": "NOT_POSITIVE_INTEGER",
+    "fieldValue": "Usermail.com"
+  },
+  "products": [
+    {
+      "product_type": {
+        "code": "NOT_ALLOWED_VALUE",
+        "fieldValue": "material"
+      },
+      "name": {
+        "code": "REQUIRED",
+        "fieldValue": null
+      }
+    },
+    {
+      "name": {
+        "code": "REQUIRED",
+        "fieldValue": ""
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Please refer to https://github.com/grupozap/squad-listings/issues/967

We have forked the repo https://github.com/vlbaluk/java-validator-livr to add the invalid field value to the response object when a validation error occurs.

Livr Roles
```json
{
    "order_id": ["required", "positive_integer"]
}
```
Data for validation
```json
{
    "order_id": -10345,
}
```

old error return
```json
{
    "order_id": "NOT_POSITIVE_INTEGER"
}
```

new error return
```json
{
    "order_id": {
        "code":"NOT_POSITIVE_INTEGER",
        "value": -10345
    }
}
```